### PR TITLE
Setup Refresh Token endpoints and fix Authorization issues

### DIFF
--- a/src/SmartLocate.API/ocelot.json
+++ b/src/SmartLocate.API/ocelot.json
@@ -120,9 +120,9 @@
       }],
       "SwaggerKey": "Identity"
     }, {
-      "UpstreamPathTemplate": "/identity/admin-users/login",
+      "UpstreamPathTemplate": "/identity/admin-users/{everything}",
       "UpstreamHttpMethod": ["POST"],
-      "DownstreamPathTemplate": "/api/identity/admin-users/login",
+      "DownstreamPathTemplate": "/api/identity/admin-users/{everything}",
       "DownstreamScheme": "http",
       "DownstreamHostAndPorts": [{
         "Host": "localhost",

--- a/src/SmartLocate.Admin/Controllers/AdminController.cs
+++ b/src/SmartLocate.Admin/Controllers/AdminController.cs
@@ -10,7 +10,7 @@ using SmartLocate.Infrastructure.Commons.Services;
 
 namespace SmartLocate.Admin.Controllers;
 
-[Authorize(Roles = SmartLocateRoles.SuperAdmin)]
+[Authorize(Policy = SmartLocateRoles.SuperAdmin)]
 [Route("api/admin")]
 [ApiController]
 public class AdminController(IMongoRepository<AdminUser> mongoRepository, ICurrentUserService currentUserService) : ControllerBase

--- a/src/SmartLocate.BusDrivers/Controllers/BusDriverController.cs
+++ b/src/SmartLocate.BusDrivers/Controllers/BusDriverController.cs
@@ -16,7 +16,7 @@ namespace SmartLocate.BusDrivers.Controllers;
 [ApiController]
 public class BusDriverController(IMongoRepository<BusDriver> mongoRepository) : ControllerBase
 {
-    [Authorize(Roles = SmartLocateRoles.Admin)]
+    [Authorize(Policy = SmartLocateRoles.Admin)]
     [HttpGet("{id:guid}")]
     [ProducesResponseType(typeof(BusDriverResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -32,7 +32,7 @@ public class BusDriverController(IMongoRepository<BusDriver> mongoRepository) : 
         return Ok(response);
     }
     
-    [Authorize(Roles = SmartLocateRoles.Admin)]
+    [Authorize(Policy = SmartLocateRoles.Admin)]
     [HttpGet]
     [ProducesResponseType(typeof(IEnumerable<BusDriverResponse>), StatusCodes.Status200OK)]
     public async Task<IActionResult> Get(int page = 1,
@@ -60,7 +60,7 @@ public class BusDriverController(IMongoRepository<BusDriver> mongoRepository) : 
         return Ok(busDriverResponses);
     }
     
-    [Authorize(Roles = SmartLocateRoles.Admin)]
+    [Authorize(Policy = SmartLocateRoles.Admin)]
     [HttpPost]
     [ProducesResponseType(typeof(BusDriverResponse), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -78,7 +78,7 @@ public class BusDriverController(IMongoRepository<BusDriver> mongoRepository) : 
         return CreatedAtAction(nameof(Get), new {id = busDriver.Id}, response);
     }
     
-    [Authorize(Roles = SmartLocateRoles.Admin)]
+    [Authorize(Policy = SmartLocateRoles.Admin)]
     [HttpPut("{id:guid}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -100,7 +100,7 @@ public class BusDriverController(IMongoRepository<BusDriver> mongoRepository) : 
         return NoContent();
     }
     
-    [Authorize(Roles = SmartLocateRoles.Admin)]
+    [Authorize(Policy = SmartLocateRoles.Admin)]
     [HttpDelete("{id:guid}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/src/SmartLocate.BusRoutes/Controllers/BusRouteController.cs
+++ b/src/SmartLocate.BusRoutes/Controllers/BusRouteController.cs
@@ -10,7 +10,7 @@ using SmartLocate.Infrastructure.Commons.Repositories;
 
 namespace SmartLocate.BusRoutes.Controllers;
 
-[Authorize(Roles = SmartLocateRoles.Admin)]
+[Authorize(Policy = SmartLocateRoles.Admin)]
 [ApiController]
 [Route("api/bus-routes")]
 public class BusRouteController(IMongoRepository<BusRoute> mongoRepository, DaprClient daprClient) : ControllerBase

--- a/src/SmartLocate.Buses/Controllers/BusController.cs
+++ b/src/SmartLocate.Buses/Controllers/BusController.cs
@@ -8,7 +8,7 @@ using SmartLocate.Infrastructure.Commons.Repositories;
 
 namespace SmartLocate.Buses.Controllers;
 
-[Authorize(Roles = SmartLocateRoles.Admin)]
+[Authorize(Policy = SmartLocateRoles.Admin)]
 [ApiController]
 [Route("api/buses")]
 public class BusController(IMongoRepository<Bus> mongoRepository) : ControllerBase

--- a/src/SmartLocate.Identity/Contracts/AdminRefreshTokenRequest.cs
+++ b/src/SmartLocate.Identity/Contracts/AdminRefreshTokenRequest.cs
@@ -1,0 +1,7 @@
+namespace SmartLocate.Identity.Contracts;
+
+public class AdminRefreshTokenRequest
+{
+    public string Token { get; set; }
+    public string RefreshToken { get; set; }
+}

--- a/src/SmartLocate.Identity/Contracts/BusDriverRefreshTokenRequest.cs
+++ b/src/SmartLocate.Identity/Contracts/BusDriverRefreshTokenRequest.cs
@@ -1,0 +1,7 @@
+namespace SmartLocate.Identity.Contracts;
+
+public class BusDriverRefreshTokenRequest
+{
+    public string Token { get; set; }
+    public string RefreshToken { get; set; }
+}

--- a/src/SmartLocate.Identity/Contracts/StudentRefreshTokenRequest.cs
+++ b/src/SmartLocate.Identity/Contracts/StudentRefreshTokenRequest.cs
@@ -1,0 +1,7 @@
+namespace SmartLocate.Identity.Contracts;
+
+public class StudentRefreshTokenRequest
+{
+    public string Token { get; set; }
+    public string RefreshToken { get; set; }
+}

--- a/src/SmartLocate.Identity/Controllers/StudentController.cs
+++ b/src/SmartLocate.Identity/Controllers/StudentController.cs
@@ -14,7 +14,8 @@ namespace SmartLocate.Identity.Controllers;
 
 [ApiController]
 [Route("api/identity/students")]
-public class StudentController(IMongoRepository<StudentActivationCode> mongoRepository, DaprClient daprClient) : ControllerBase
+public class StudentController(IMongoRepository<StudentActivationCode> activationCodeRepository, 
+    IMongoRepository<StudentRefreshToken> refreshTokenRepository, DaprClient daprClient) : ControllerBase
 {
     private readonly Random _random = new();
     
@@ -33,12 +34,12 @@ public class StudentController(IMongoRepository<StudentActivationCode> mongoRepo
         
         var activationCode = _random.Next(1000, 9999);
         
-        var existingActivationCode = await mongoRepository.FirstOrDefaultAsync(x => x.StudentId == request.StudentId);
+        var existingActivationCode = await activationCodeRepository.FirstOrDefaultAsync(x => x.StudentId == request.StudentId);
         if (existingActivationCode != null)
         {
             existingActivationCode.ActivationCode = activationCode;
             existingActivationCode.CreatedAt = DateTime.UtcNow;
-            await mongoRepository.UpdateAsync(existingActivationCode);
+            await activationCodeRepository.UpdateAsync(existingActivationCode);
         }
         else
         {
@@ -48,7 +49,7 @@ public class StudentController(IMongoRepository<StudentActivationCode> mongoRepo
                 ActivationCode = activationCode,
                 CreatedAt = DateTime.UtcNow
             };
-            await mongoRepository.CreateAsync(newActivationCode);
+            await activationCodeRepository.CreateAsync(newActivationCode);
         }
         
         await daprClient.PublishEventAsync(SmartLocateComponents.PubSub, SmartLocateTopics.SendMail,
@@ -68,7 +69,7 @@ public class StudentController(IMongoRepository<StudentActivationCode> mongoRepo
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> Activate(StudentActivateRequest request)
     {
-        var activationCode = await mongoRepository.FirstOrDefaultAsync(x => x.StudentId == request.StudentId);
+        var activationCode = await activationCodeRepository.FirstOrDefaultAsync(x => x.StudentId == request.StudentId);
         if (activationCode == null)
         {
             return NotFound("Activation Code Not Found");
@@ -79,7 +80,7 @@ public class StudentController(IMongoRepository<StudentActivationCode> mongoRepo
         }
         if (activationCode.CreatedAt.AddMinutes(5) < DateTime.UtcNow)
         {
-            await mongoRepository.RemoveAsync(activationCode.Id);
+            await activationCodeRepository.RemoveAsync(activationCode.Id);
             return BadRequest("Activation Code expired");
         }
         if (request.Password != request.ConfirmPassword)
@@ -97,7 +98,7 @@ public class StudentController(IMongoRepository<StudentActivationCode> mongoRepo
             request.Password
         });
         
-        await mongoRepository.RemoveAsync(activationCode.Id);
+        await activationCodeRepository.RemoveAsync(activationCode.Id);
         
         return Accepted("Activation Code Accepted");
     }
@@ -128,14 +129,35 @@ public class StudentController(IMongoRepository<StudentActivationCode> mongoRepo
             };
             
             var secret = jwtSettings.Value.Secret;
-            var token = JwtHelper.GenerateJwtToken(secret, DateTime.UtcNow.AddDays(4), claims);
-            var refreshToken = JwtHelper.GenerateRefreshToken();
+            var createdAtDate = DateTime.UtcNow;
+            var expiresAtDate = createdAtDate.AddDays(4);
+            var tokenString = JwtHelper.GenerateJwtToken(secret, expiresAtDate, claims);
+            var refreshTokenString = JwtHelper.GenerateRefreshToken();
+            
+            var existingRefreshToken = await refreshTokenRepository.FirstOrDefaultAsync(x => x.StudentId == response.Id);
+            if (existingRefreshToken is not null)
+            {
+                existingRefreshToken.RefreshToken = refreshTokenString;
+                existingRefreshToken.CreatedAt = createdAtDate;
+                existingRefreshToken.ExpiresAt = expiresAtDate;
+                await refreshTokenRepository.UpdateAsync(existingRefreshToken);
+            }
+            else
+            {
+                await refreshTokenRepository.CreateAsync(new StudentRefreshToken
+                {
+                    StudentId = response.Id.GetValueOrDefault(),
+                    RefreshToken = refreshTokenString,
+                    CreatedAt = createdAtDate,
+                    ExpiresAt = expiresAtDate
+                });
+            }
             
             var tokenResponse = new StudentLoginResponse
             {
-                Token = token,
-                RefreshToken = refreshToken,
-                ExpiresAt = DateTime.UtcNow.AddDays(4)
+                Token = tokenString,
+                RefreshToken = refreshTokenString,
+                ExpiresAt = expiresAtDate
             };
             
             return Ok(tokenResponse);
@@ -143,6 +165,51 @@ public class StudentController(IMongoRepository<StudentActivationCode> mongoRepo
         catch (HttpRequestException e)
         {
             return e.StatusCode is HttpStatusCode.NotFound ? NotFound(e.Message) : BadRequest(e.Message);
+        }
+        catch (Exception e)
+        {
+            return BadRequest(e.Message);
+        }
+    }
+    
+    [HttpPost("refresh-token")]
+    [ProducesResponseType(typeof(StudentLoginResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> RefreshToken(StudentRefreshTokenRequest request, 
+        [FromServices] IOptions<JwtSettings> jwtSettings)
+    {
+        try
+        {
+            var secret = jwtSettings.Value.Secret;
+            var claimsPrincipal = JwtHelper.GetPrincipalFromToken(request.Token, secret);
+            var studentId = Guid.Parse(claimsPrincipal.Claims.First(x => x.Type == SmartLocateClaimTypes.StudentId).Value);
+            
+            var existingRefreshToken = await refreshTokenRepository.FirstOrDefaultAsync(x => x.StudentId == studentId);
+            if (existingRefreshToken is null 
+                || existingRefreshToken.RefreshToken != request.RefreshToken
+                || existingRefreshToken.ExpiresAt <= DateTime.UtcNow)
+            {
+                return BadRequest("Invalid Refresh Token");
+            }
+            
+            var createdAtDate = DateTime.UtcNow;
+            var expiresAtDate = createdAtDate.AddDays(4);
+            var tokenString = JwtHelper.GenerateJwtToken(secret, expiresAtDate, claimsPrincipal.Claims);
+            var refreshTokenString = JwtHelper.GenerateRefreshToken();
+            
+            existingRefreshToken.RefreshToken = refreshTokenString;
+            existingRefreshToken.CreatedAt = createdAtDate;
+            existingRefreshToken.ExpiresAt = expiresAtDate;
+            await refreshTokenRepository.UpdateAsync(existingRefreshToken);
+            
+            var tokenResponse = new StudentLoginResponse
+            {
+                Token = tokenString,
+                RefreshToken = refreshTokenString,
+                ExpiresAt = expiresAtDate
+            };
+            
+            return Ok(tokenResponse);
         }
         catch (Exception e)
         {

--- a/src/SmartLocate.Identity/Entities/AdminUserRefreshToken.cs
+++ b/src/SmartLocate.Identity/Entities/AdminUserRefreshToken.cs
@@ -1,0 +1,18 @@
+using SmartLocate.Commons.Attributes;
+using SmartLocate.Infrastructure.Commons.Contracts;
+
+namespace SmartLocate.Identity.Entities;
+
+[Collection("AdminUserRefreshTokens")]
+public class AdminUserRefreshToken : IEntity
+{
+    public Guid Id { get; set; }
+    
+    public Guid AdminUserId { get; set; }
+    
+    public string RefreshToken { get; set; }
+    
+    public DateTime CreatedAt { get; set; }
+    
+    public DateTime ExpiresAt { get; set; }
+}

--- a/src/SmartLocate.Identity/Entities/BusDriverRefreshToken.cs
+++ b/src/SmartLocate.Identity/Entities/BusDriverRefreshToken.cs
@@ -1,0 +1,18 @@
+using SmartLocate.Commons.Attributes;
+using SmartLocate.Infrastructure.Commons.Contracts;
+
+namespace SmartLocate.Identity.Entities;
+
+[Collection("BusDriverRefreshTokens")]
+public class BusDriverRefreshToken : IEntity
+{
+    public Guid Id { get; set; }
+    
+    public Guid BusDriverId { get; set; }
+    
+    public string RefreshToken { get; set; }
+    
+    public DateTime CreatedAt { get; set; }
+    
+    public DateTime ExpiresAt { get; set; }
+}

--- a/src/SmartLocate.Identity/Entities/StudentRefreshToken.cs
+++ b/src/SmartLocate.Identity/Entities/StudentRefreshToken.cs
@@ -1,0 +1,18 @@
+using SmartLocate.Commons.Attributes;
+using SmartLocate.Infrastructure.Commons.Contracts;
+
+namespace SmartLocate.Identity.Entities;
+
+[Collection("StudentRefreshTokens")]
+public class StudentRefreshToken : IEntity
+{
+    public Guid Id { get; set; }
+    
+    public Guid StudentId { get; set; }
+    
+    public string RefreshToken { get; set; }
+    
+    public DateTime CreatedAt { get; set; }
+    
+    public DateTime ExpiresAt { get; set; }
+}

--- a/src/SmartLocate.Identity/Program.cs
+++ b/src/SmartLocate.Identity/Program.cs
@@ -13,7 +13,10 @@ builder.AddMongoDBClient("MongoDbConnection");
 
 builder.Services
     .AddMongoRepository<StudentActivationCode>()
-    .AddMongoRepository<BusDriverActivationCode>();
+    .AddMongoRepository<BusDriverActivationCode>()
+    .AddMongoRepository<AdminUserRefreshToken>()
+    .AddMongoRepository<BusDriverRefreshToken>()
+    .AddMongoRepository<StudentRefreshToken>();
 
 builder.Services.AddJwtAuthentication();
 

--- a/src/SmartLocate.Infrastructure.Commons/Extensions/ServiceCollectionExtensions.cs
+++ b/src/SmartLocate.Infrastructure.Commons/Extensions/ServiceCollectionExtensions.cs
@@ -48,13 +48,14 @@ public static class ServiceCollectionExtensions
                     ValidateLifetime = false,
                     ValidateIssuerSigningKey = true,
                     IssuerSigningKey = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(jwtSecret)),
+                    RoleClaimType = SmartLocateClaimTypes.Type
                 };
             });
         services.AddAuthorizationBuilder()
-            .AddPolicy(SmartLocateRoles.SuperAdmin, policy => policy.RequireClaim(SmartLocateClaimTypes.Type, SmartLocateRoles.SuperAdmin))
-            .AddPolicy(SmartLocateRoles.Admin, policy => policy.RequireClaim(SmartLocateClaimTypes.Type, SmartLocateRoles.Admin, SmartLocateRoles.SuperAdmin))
-            .AddPolicy(SmartLocateRoles.Student, policy => policy.RequireClaim(SmartLocateClaimTypes.Type, SmartLocateRoles.Student))
-            .AddPolicy(SmartLocateRoles.BusDriver, policy => policy.RequireClaim(SmartLocateClaimTypes.Type, SmartLocateRoles.BusDriver))
+            .AddPolicy(SmartLocateRoles.SuperAdmin, policy => policy.RequireRole(SmartLocateRoles.SuperAdmin))
+            .AddPolicy(SmartLocateRoles.Admin, policy => policy.RequireRole(SmartLocateRoles.Admin, SmartLocateRoles.SuperAdmin))
+            .AddPolicy(SmartLocateRoles.Student, policy => policy.RequireRole(SmartLocateRoles.Student))
+            .AddPolicy(SmartLocateRoles.BusDriver, policy => policy.RequireRole(SmartLocateRoles.BusDriver))
             .SetDefaultPolicy(new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build());
         return services;
     }

--- a/src/SmartLocate.Students/Controllers/StudentController.cs
+++ b/src/SmartLocate.Students/Controllers/StudentController.cs
@@ -18,7 +18,7 @@ namespace SmartLocate.Students.Controllers;
 [Route("api/students")]
 public class StudentController(IMongoRepository<Student> mongoRepository, DaprClient daprClient) : ControllerBase
 {
-    [Authorize(Roles = SmartLocateRoles.Admin)]
+    [Authorize(Policy = SmartLocateRoles.Admin)]
     [HttpGet("{id:guid}")]
     [ProducesResponseType(typeof(StudentResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -36,7 +36,7 @@ public class StudentController(IMongoRepository<Student> mongoRepository, DaprCl
         return Ok(studentResponse);
     }
 
-    [Authorize(Roles = SmartLocateRoles.Admin)]
+    [Authorize(Policy = SmartLocateRoles.Admin)]
     [HttpGet]
     [ProducesResponseType(typeof(IEnumerable<StudentResponse>), StatusCodes.Status200OK)]
     public async Task<IActionResult> Get(int page = 1,
@@ -83,7 +83,7 @@ public class StudentController(IMongoRepository<Student> mongoRepository, DaprCl
         return Ok(studentResponses);
     }
     
-    [Authorize(Roles = SmartLocateRoles.Admin)]
+    [Authorize(Policy = SmartLocateRoles.Admin)]
     [HttpPost]
     [ProducesResponseType(typeof(StudentResponse), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -135,7 +135,7 @@ public class StudentController(IMongoRepository<Student> mongoRepository, DaprCl
         return CreatedAtAction(nameof(Get), new { id = student.Id }, response);
     }
     
-    [Authorize(Roles = SmartLocateRoles.Admin)]
+    [Authorize(Policy = SmartLocateRoles.Admin)]
     [HttpPut("{id:guid}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -188,7 +188,7 @@ public class StudentController(IMongoRepository<Student> mongoRepository, DaprCl
         return NoContent();
     }
 
-    [Authorize(Roles = SmartLocateRoles.Admin)]
+    [Authorize(Policy = SmartLocateRoles.Admin)]
     [HttpDelete("{id:guid}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]


### PR DESCRIPTION
- Implements the refresh token endpoints for refreshing the JWT Tokens for all users - `AdminUser`, `BusDriver` and `Student`.
- Changes all the `Authorize` attributes to use `Policy =` instead of `Role =`, to make use the registered Authorization Policies, rather than directly using roles for authorization.