### PR TITLE
Improve paginated results for GetAll endpoints in all microservices

### DIFF
--- a/src/SmartLocate.Admin/Controllers/AdminController.cs
+++ b/src/SmartLocate.Admin/Controllers/AdminController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using SmartLocate.Admin.Contracts;
 using SmartLocate.Admin.Entities;
 using SmartLocate.Commons.Constants;
+using SmartLocate.Infrastructure.Commons.Contracts;
 using SmartLocate.Infrastructure.Commons.Repositories;
 using SmartLocate.Infrastructure.Commons.Services;
 
@@ -31,7 +32,7 @@ public class AdminController(IMongoRepository<AdminUser> mongoRepository, ICurre
     }
     
     [HttpGet]
-    [ProducesResponseType(typeof(IEnumerable<AdminUserResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ResultSet<AdminUserResponse>), StatusCodes.Status200OK)]
     public async Task<IActionResult> Get(int page = 1,
                                         int pageSize = 10,
                                         string orderBy = "Name",
@@ -46,9 +47,10 @@ public class AdminController(IMongoRepository<AdminUser> mongoRepository, ICurre
         };
         var skip = (page - 1) * pageSize;
         var adminUsers = await mongoRepository.GetAllAsync(skip, pageSize, orderByExpression, orderByDescending);
+        var totalCount = await mongoRepository.CountAsync();
         var adminUserResponses = adminUsers
             .Select(x => new AdminUserResponse(x.Id, x.Name, x.Email, x.PhoneNumber, x.IsSuperAdmin)).ToList();
-        return Ok(adminUserResponses);
+        return Ok(new ResultSet<AdminUserResponse>(adminUserResponses, totalCount));
     }
 
     [HttpPost]

--- a/src/SmartLocate.BusDrivers/Controllers/BusDriverController.cs
+++ b/src/SmartLocate.BusDrivers/Controllers/BusDriverController.cs
@@ -7,6 +7,7 @@ using SmartLocate.BusDrivers.Contracts;
 using SmartLocate.BusDrivers.Entities;
 using SmartLocate.BusDrivers.Enums;
 using SmartLocate.Commons.Constants;
+using SmartLocate.Infrastructure.Commons.Contracts;
 using SmartLocate.Infrastructure.Commons.Repositories;
 
 namespace SmartLocate.BusDrivers.Controllers;
@@ -34,7 +35,7 @@ public class BusDriverController(IMongoRepository<BusDriver> mongoRepository) : 
     
     [Authorize(Policy = SmartLocateRoles.Admin)]
     [HttpGet]
-    [ProducesResponseType(typeof(IEnumerable<BusDriverResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ResultSet<BusDriverResponse>), StatusCodes.Status200OK)]
     public async Task<IActionResult> Get(int page = 1,
                                         int pageSize = 10,
                                         string orderBy = "Name",
@@ -55,9 +56,10 @@ public class BusDriverController(IMongoRepository<BusDriver> mongoRepository) : 
         };
         var skip = (page - 1) * pageSize;
         var busDrivers = await mongoRepository.GetAllAsync(filter, skip, pageSize, orderByExpression, orderByDescending);
+        var totalCount = await mongoRepository.CountAsync(filter);
         var busDriverResponses = busDrivers
             .Select(x => new BusDriverResponse(x.Id, x.Name, x.PhoneNumber, x.IsActivated)).ToList();
-        return Ok(busDriverResponses);
+        return Ok(new ResultSet<BusDriverResponse>(busDriverResponses, totalCount));
     }
     
     [Authorize(Policy = SmartLocateRoles.Admin)]

--- a/src/SmartLocate.BusRoutes/Controllers/BusRouteController.cs
+++ b/src/SmartLocate.BusRoutes/Controllers/BusRouteController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using SmartLocate.BusRoutes.Contracts;
 using SmartLocate.BusRoutes.Entities;
 using SmartLocate.Commons.Constants;
+using SmartLocate.Infrastructure.Commons.Contracts;
 using SmartLocate.Infrastructure.Commons.Repositories;
 
 namespace SmartLocate.BusRoutes.Controllers;
@@ -30,7 +31,7 @@ public class BusRouteController(IMongoRepository<BusRoute> mongoRepository, Dapr
     }
     
     [HttpGet]
-    [ProducesResponseType(typeof(IEnumerable<BusRouteResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ResultSet<BusRouteResponse>), StatusCodes.Status200OK)]
     public async Task<IActionResult> Get(int page = 1, int pageSize = 10, string orderBy = "Id", bool orderByDescending = false)
     {
         Expression<Func<BusRoute, object>> orderByExpression = orderBy switch
@@ -40,8 +41,9 @@ public class BusRouteController(IMongoRepository<BusRoute> mongoRepository, Dapr
         };
         var skip = (page - 1) * pageSize;
         var busRoutes = await mongoRepository.GetAllAsync(skip, pageSize, orderByExpression, orderByDescending);
+        var totalCount = await mongoRepository.CountAsync();
         var busRouteResponses = busRoutes.Select(busRoute => new BusRouteResponse(busRoute.Id, busRoute.RouteNumber, busRoute.StartLocation, busRoute.RoutePoints)).ToList();
-        return Ok(busRouteResponses);
+        return Ok(new ResultSet<BusRouteResponse>(busRouteResponses, totalCount));
     }
     
     [HttpPost]

--- a/src/SmartLocate.Buses/Controllers/BusController.cs
+++ b/src/SmartLocate.Buses/Controllers/BusController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using SmartLocate.Buses.Contracts;
 using SmartLocate.Buses.Entities;
 using SmartLocate.Commons.Constants;
+using SmartLocate.Infrastructure.Commons.Contracts;
 using SmartLocate.Infrastructure.Commons.Repositories;
 
 namespace SmartLocate.Buses.Controllers;
@@ -28,7 +29,7 @@ public class BusController(IMongoRepository<Bus> mongoRepository) : ControllerBa
     }
     
     [HttpGet]
-    [ProducesResponseType(typeof(IEnumerable<BusResponse>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ResultSet<BusResponse>), StatusCodes.Status200OK)]
     public async Task<IActionResult> Get(int page = 1, int pageSize = 10, string orderBy = "Id", bool orderByDescending = false)
     {
         Expression<Func<Bus, object>> orderByExpression = orderBy switch
@@ -39,8 +40,9 @@ public class BusController(IMongoRepository<Bus> mongoRepository) : ControllerBa
         };
         var skip = (page - 1) * pageSize;
         var buses = await mongoRepository.GetAllAsync(skip, pageSize, orderByExpression, orderByDescending);
+        var totalCount = await mongoRepository.CountAsync();
         var busResponses = buses.Select(bus => new BusResponse(bus.Id, bus.VehicleNumber, bus.VehicleModel)).ToList();
-        return Ok(busResponses);
+        return Ok(new ResultSet<BusResponse>(busResponses, totalCount));
     }
     
     [HttpPost]

--- a/src/SmartLocate.Infrastructure.Commons/Contracts/ResultSet.cs
+++ b/src/SmartLocate.Infrastructure.Commons/Contracts/ResultSet.cs
@@ -1,0 +1,8 @@
+namespace SmartLocate.Infrastructure.Commons.Contracts;
+
+public class ResultSet<T>(IEnumerable<T> items, long totalCount) where T : class
+{
+    public List<T> Items { get; set; } = items.ToList();
+    
+    public long TotalCount { get; set; } = totalCount;
+}


### PR DESCRIPTION
Modify Response format for GetAll endpoints in all microservices by introducing a new wrapper class `ResultSet<T>` that stores `List<T>` items and `long` count.